### PR TITLE
Add missing permissions

### DIFF
--- a/source/Enum/Authorization/Permissions.php
+++ b/source/Enum/Authorization/Permissions.php
@@ -56,4 +56,14 @@ class Permissions extends Enum
      *
      */
     const DIRECT_PAYMENT = 'DIRECT_PAYMENT';
+
+    /**
+     *
+     */
+    const REFUND_TRANSACTIONS = 'REFUND_TRANSACTIONS';
+
+    /**
+     *
+     */
+    const CANCEL_TRANSACTIONS = 'CANCEL_TRANSACTIONS';
 }


### PR DESCRIPTION
When I was trying to cancel and refund transactions via application I came acrros two missing permission types.

```php
$authorization = new \PagSeguro\Domains\Requests\Authorization();

$authorization->addPermission(\PagSeguro\Enum\Authorization\Permissions::REFUND_TRANSACTIONS);
$authorization->addPermission(\PagSeguro\Enum\Authorization\Permissions::CANCEL_TRANSACTIONS);
```
