### PR TITLE
Correção de parâmetro que não implementa countable

### DIFF
--- a/source/Domains/Requests/PaymentMethod.php
+++ b/source/Domains/Requests/PaymentMethod.php
@@ -64,6 +64,10 @@ trait PaymentMethod
 
     public function paymentMethodLenght()
     {
-        return count((array) $this->paymentMethod);
+        if((current($this->paymentMethod) instanceof \Countable) || \is_array(current($this->paymentMethod))) {
+            return count(current($this->paymentMethod));
+        }
+        
+        return count($this->paymentMethod);
     }
 }


### PR DESCRIPTION
Estas linhas geravam um warning que reclamava que o parâmetro em questão pode não ser do tipo Countable