### PR TITLE
Correção de parâmetro que não implementa countable

### DIFF
--- a/source/Domains/Requests/Item.php
+++ b/source/Domains/Requests/Item.php
@@ -64,6 +64,10 @@ trait Item
 
     public function itemLenght()
     {
-        return count(current($this->items));
+        if((current($this->items) instanceof \Countable) || \is_array(current($this->items))) {
+            return count(current($this->items));
+        }
+
+        return count($this->items);
     }
 }


### PR DESCRIPTION
Estas linhas geravam um warning que reclamava que o parâmetro em questão pode não ser do tipo Countable